### PR TITLE
patch poms

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
-#ECCN:Open Source

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>build-tools</artifactId>

--- a/jaxrs-to-raml/jaxrs-api/pom.xml
+++ b/jaxrs-to-raml/jaxrs-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-api</artifactId>

--- a/jaxrs-to-raml/jaxrs-parser/pom.xml
+++ b/jaxrs-to-raml/jaxrs-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-parser</artifactId>

--- a/jaxrs-to-raml/jaxrs-test-resources/pom.xml
+++ b/jaxrs-to-raml/jaxrs-test-resources/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-test-resources</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-cli/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-cli</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-converter/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-converter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-converter</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-core/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-core</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-gradle-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-gradle-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-annotations/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-annotations</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-methods/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-methods/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-methods</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-multipart/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-multipart/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-multipart</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-raml-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-raml-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-raml-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-types/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/jaxrs-to-raml-types/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-types</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/jaxrs-to-raml-maven-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-maven-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-examples/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-examples</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-gradle-plugin-wrapper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-gradle-plugin-wrapper</artifactId>

--- a/jaxrs-to-raml/jaxrs-to-raml-maven-plugin/pom.xml
+++ b/jaxrs-to-raml/jaxrs-to-raml-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml-maven-plugin</artifactId>

--- a/jaxrs-to-raml/pom.xml
+++ b/jaxrs-to-raml/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-to-raml</artifactId>

--- a/jaxrs-to-raml/raml-api/pom.xml
+++ b/jaxrs-to-raml/raml-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-api</artifactId>

--- a/jaxrs-to-raml/raml-emitter/pom.xml
+++ b/jaxrs-to-raml/raml-emitter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-emitter</artifactId>

--- a/jaxrs-to-raml/raml-generator-api/pom.xml
+++ b/jaxrs-to-raml/raml-generator-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>jaxrs-to-raml</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-generator-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.raml.jaxrs</groupId>
     <artifactId>raml-for-jaxrs</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7</version>
     <packaging>pom</packaging>
     <name>raml-for-jaxrs</name>
     <description>This project is all about two way transformation of JAX-RS-annotated Java code to RAML API description and back.</description>

--- a/raml-to-jaxrs/examples/gradle-examples/pom.xml
+++ b/raml-to-jaxrs/examples/gradle-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-gradle-examples</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/feature-plugins/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/feature-plugins/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>features</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>feature-plugins</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/feature-raml-project/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/feature-raml-project/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>features</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>feature-raml-project</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/features/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>features</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/jaxb-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/jaxb-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxb-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/multipart/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/multipart/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>multipart</artifactId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.raml.jaxrs</groupId>
             <artifactId>jaxrs-code-generator</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/raml-to-jaxrs/examples/maven-examples/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <!-- Repeating here for documentation -->
@@ -39,7 +39,7 @@
                 <plugin>
                     <groupId>org.raml.jaxrs</groupId>
                     <artifactId>raml-to-jaxrs-maven-plugin</artifactId>
-                    <version>3.0.6-SNAPSHOT</version>
+                    <version>3.0.7</version>
                     <executions>
                         <execution>
                             <goals>

--- a/raml-to-jaxrs/examples/maven-examples/raml-defined-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/raml-defined-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-defined-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/references/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/references/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>references</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/scalar-types/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/scalar-types/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>scalar-types</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-json-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-json-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>simple-json-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-raml08/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-raml08/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>simple-raml08</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/simple-xml-example/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/simple-xml-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>simple-xml-example</artifactId>

--- a/raml-to-jaxrs/examples/maven-examples/type-torture-test/pom.xml
+++ b/raml-to-jaxrs/examples/maven-examples/type-torture-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>maven-examples</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>type-torture-test</artifactId>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.raml.jaxrs</groupId>
             <artifactId>jaxrs-code-generator</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/raml-to-jaxrs/examples/pom.xml
+++ b/raml-to-jaxrs/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
     <artifactId>examples</artifactId>
     <packaging>pom</packaging>

--- a/raml-to-jaxrs/jaxrs-code-generator/pom.xml
+++ b/raml-to-jaxrs/jaxrs-code-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>jaxrs-code-generator</artifactId>

--- a/raml-to-jaxrs/pom.xml
+++ b/raml-to-jaxrs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>raml-to-jaxrs</artifactId>

--- a/raml-to-jaxrs/raml-to-jaxrs-cli/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
     <artifactId>raml-to-jaxrs-cli</artifactId>
 

--- a/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-gradle-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-gradle-plugin-wrapper</artifactId>

--- a/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
+++ b/raml-to-jaxrs/raml-to-jaxrs-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-to-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>raml-to-jaxrs-maven-plugin</artifactId>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.raml.jaxrs</groupId>
         <artifactId>raml-for-jaxrs</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7</version>
     </parent>
 
     <artifactId>utilities</artifactId>


### PR DESCRIPTION
Apply pom file updates to our fork for raml-for-jax-rs.

I'll plan to build the jar and park it in https://github.com/VEuPathDB/maven-packages/tree/main/raw-packages

Related to https://github.com/VEuPathDB/ui-infra-backend-issues/issues/16